### PR TITLE
Fixed LEDs getting stuck in an undefined state

### DIFF
--- a/ppd_field_test/ppd_field_test.ino
+++ b/ppd_field_test/ppd_field_test.ino
@@ -1014,6 +1014,8 @@ boolean ledSetup(int brightness){
     strand2.begin();
     strand2.setBrightness(brightness);
     strand2.show();
+
+    ledSet (0, 0, 0);
     
     return true;
 }


### PR DESCRIPTION
I was able to duplicate the LED undefined state by quickly unplugging
and plugging the device power back int. By setting the LEDs to 0 (dark)
during LED init, the LEDs will turn off. Note that this doesn't prevent
the LEDs from getting into the weird state, but it does appear to fix
it.
